### PR TITLE
mongoの認証を通すようにした

### DIFF
--- a/zconvd.py
+++ b/zconvd.py
@@ -2,6 +2,7 @@
 import zoomify_im
 import pymongo
 import datetime
+import os
 import os.path
 import uuid
 import shutil
@@ -26,8 +27,10 @@ class Zconvd:
 
     def connect(self):
         self.conn = pymongo.Connection()
-        self.col_que = self.conn[self.dbName][self.colQue]
-        self.col_img = self.conn[self.dbName][self.colImg]
+	db = self.conn[self.dbName]
+	db.authenticate(os.environ["DB_USER"], os.environ["DB_PASS"])
+        self.col_que = db[self.colQue]
+        self.col_img = db[self.colImg]
 
     def disconnect(self):
         self.conn.disconnect()


### PR DESCRIPTION
## 概要
`zconvd.py`がmongoにアクセスする際にmongoの認証を通すようにしました

## 変更内容
bashの環境変数 `DB_USER` `DB_PASS`をmongoの認証に通してます
```python 
db.authenticate(os.environ["DB_USER"], os.environ["DB_PASS"])
```


## 注意事項
`sudo`のオプションに`-E`をつけないと環境変数を読み込めません
`sudo -E python zconvd.py archives`
sudoの実行時にbashの環境変数のリセットが入るためです